### PR TITLE
fix(docs): Remove support reference from security docs

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,6 @@ We advise users to run or update to the most recent release of this project. Old
 
 ## Reporting a Vulnerability
 
-The F5 Security Incident Response Team (F5 SIRT) offers two methods to easily report potential security vulnerabilities:
-
-- If you’re an F5 customer with an active support contract, please contact [F5 Technical Support](https://www.f5.com/support).
-- If you aren’t an F5 customer, please report any potential or current instances of security vulnerabilities in any F5 product to the F5 Security Incident Response Team at <f5sirt@f5.com>.
+The F5 Security Incident Response Team (F5 SIRT) requests that you report any potential or current instances of security vulnerabilities in any F5 product to the F5 Security Incident Response Team at <f5sirt@f5.com>.
 
 For more information, please read the F5 SIRT vulnerability reporting guidelines available at [https://www.f5.com/support/report-a-vulnerability](https://www.f5.com/support/report-a-vulnerability).


### PR DESCRIPTION
### Proposed changes

Per F5 Security advice, changing templated SECURITY file to remove Support reference.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`CHANGELOG.md`](/CHANGELOG.md)).
